### PR TITLE
Respect animate flag when setting progress

### DIFF
--- a/LDProgressView/LDProgressView.m
+++ b/LDProgressView/LDProgressView.m
@@ -55,12 +55,18 @@
     }
 }
 
+
 - (void)setProgress:(CGFloat)progress {
     self.progressToAnimateTo = progress;
-    if (self.animationTimer) {
-        [self.animationTimer invalidate];
+    if ([self.animate boolValue]) {
+        if (self.animationTimer) {
+            [self.animationTimer invalidate];
+        }
+        self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:0.008 target:self selector:@selector(incrementAnimatingProgress) userInfo:nil repeats:YES];
+    } else {
+        _progress = progress;
+        [self setNeedsDisplay];
     }
-    self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:0.008 target:self selector:@selector(incrementAnimatingProgress) userInfo:nil repeats:YES];
 }
 
 - (void)incrementAnimatingProgress {

--- a/LDProgressView/LDViewController.m
+++ b/LDProgressView/LDViewController.m
@@ -51,6 +51,7 @@
     progressView.showText = @NO;
     progressView.progress = 0.40;
     progressView.borderRadius = @5;
+    progressView.animate = @NO;
     progressView.type = LDProgressSolid;
     [self.progressViews addObject:progressView];
     [self.view addSubview:progressView];
@@ -59,6 +60,7 @@
     progressView = [[LDProgressView alloc] initWithFrame:CGRectMake(20, 250, self.view.frame.size.width-40, 22)];
     progressView.progress = 0.40;
     progressView.borderRadius = @0;
+    progressView.animate = @NO;
     progressView.type = LDProgressStripes;
     progressView.color = [UIColor orangeColor];
     [self.progressViews addObject:progressView];


### PR DESCRIPTION
This is the change I made so that when you reuse the progress view (for instance, to reset to zero), you don't have to have the progress bar animate all the way down - the animate flag is now checked when setting progress.

I also updated the demo view controller so that the non-animated progress bars don't animate. You can see the difference by running the demo app.
